### PR TITLE
Set property_id of References on .save()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiller",
-  "version": "0.1.30",
+  "version": "0.1.40",
   "description": "MongoDB ODM for TypeScript",
   "keywords": [
     "mongodb",

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -44,16 +44,19 @@ export class Document {
                     await this[key].save(saveDeep);
                 }
                 copy[key + '_id'] = this[key]._id;
+                this[key + '_id'] = this[key]._id;
             }
 
             // this[key] is an array, holding referenced documents
             else if (isArray(this[key]) && __document['references'][key]) {
                 copy[key + '_id'] = [];
+                this[key + '_id'] = [];
                 for (var v of this[key]) {
                     if (saveDeep && v.isNew()) {
                         await v.save(saveDeep)
                     }
                     copy[key + '_id'].push(v ? v._id : null);
+                    this[key + '_id'].push(v ? v._id : null);
                 }
             }
 

--- a/test/CollectionTest.ts
+++ b/test/CollectionTest.ts
@@ -108,6 +108,15 @@ describe('Collection', () => {
                 expect(e).to.be.an.instanceOf(ValidationError)
             }
         })
+
+        it('sets property_id of references on save', async() => {
+            let user = await new User('anna').save();
+            let file = await new File('name1');
+            file.owner = user;
+            await file.save();
+
+            expect(file.owner_id.toString()).to.eq(user._id.toString());
+        })
     })
 
     describe('#save(..., true)', () => {

--- a/test/models.ts
+++ b/test/models.ts
@@ -6,6 +6,7 @@ import {embed} from "../src/decorators/embed";
 import {ordered} from "../src/decorators/ordered";
 import {validate, validateDocument, ValidationResult} from "../src/decorators/validate";
 import {index} from "../src/decorators/index";
+import {ObjectID} from 'mongodb';
 
 @collection()
 export class User extends Collection {
@@ -27,9 +28,11 @@ export class File extends Collection {
 
     @reference(User)
     owner:User
+    owner_id: ObjectID;
 
     @reference([User])
     editors:Array<User>
+    editors_id: ObjectID[];
     
     constructor(name:string, owner?:User) {
         super();


### PR DESCRIPTION
Makes object behavior more predictable by setting property_ids of references on saving operations, as it is preserved on loading operations.  

More ideal change for the future would be settings these on reference insertion via getter/setters as discussed.

Also, I'm not quite sure if there's a need for the copy-obj in Document.toDB().