### PR TITLE
Apply sorts before limits

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -55,11 +55,11 @@ export abstract class Collection extends Document {
         let type = this.__type || (this._collectionName ? this : null);
         let coll = await DB.collection((<any>type)._collectionName);
         let cursor = coll.find(selector);
-        if (typeof(limit) == 'number') {
-            cursor = cursor.limit(limit);
-        }
         if (sort) {
             cursor = cursor.sort(sort);
+        }
+        if (typeof(limit) == 'number') {
+            cursor = cursor.limit(limit);
         }
         let docs = await cursor.toArray();
         return Bluebird.map<any, Type>(docs, async (doc) => {

--- a/test/CollectionTest.ts
+++ b/test/CollectionTest.ts
@@ -270,6 +270,20 @@ describe('Collection', () => {
             expect(await User.find<User>({}, null, {id: 1})).to.have.length(3);
             expect(await User.find<User>({}, 1, {id: 1})).to.have.length(1);
         })
+
+        it('applies sorts before limits', async() => {
+            let lucy = await new User('lucy').save();
+            let alice = await new User('alice').save();
+            let bob = await new User('bob').save();
+
+            let users = await User.find<User>({}, 1, {id: 1});
+            expect(users).to.have.length(1);
+            expect(users[0].id).to.eqls('alice');
+
+            users = await User.find<User>({}, 2, {id: -1});
+            expect(users).to.have.length(2);
+            expect(users.map(u => u.id)).to.eqls(['lucy', 'bob']);
+        })
     });
 
     describe('#all()', () => {


### PR DESCRIPTION
## What changes does this PR introduce?

* currently it the order of operations was not logical regarding `.sort()` and `.limit()`
* limiting a cursor should happen after it has been sorted, otherwise you'll get get unpredictable results
* this PR changes the order of operations, and introduces a test to make sure its called in the right order